### PR TITLE
[fix] UITextAlignmentCenter deprecated since iOS 6.0

### DIFF
--- a/CXAlertView/CXAlertView.m
+++ b/CXAlertView/CXAlertView.m
@@ -14,11 +14,13 @@
 #import <QuartzCore/QuartzCore.h>
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0
-	#define LBM NSLineBreakByTruncatingTail
-	#define BT_LBM NSLineBreakByWordWrapping
+    #define LBM NSLineBreakByTruncatingTail
+    #define BT_LBM NSLineBreakByWordWrapping
+    #define TA_CENTER NSTextAlignmentCenter
 #else
-	#define LBM UILineBreakModeTailTruncation
-	#define BT_LBM UILineBreakModeWordWrap
+    #define LBM UILineBreakModeTailTruncation
+    #define BT_LBM UILineBreakModeWordWrap
+    #define TA_CENTER UITextAlignmentCenter
 #endif
 
 #import "LFGlassView.h"
@@ -785,7 +787,7 @@ static CXAlertView *__cx_alert_current_view;
     button.defaultRightLineVisible = _showButtonLine;
     [button setTitle:title forState:UIControlStateNormal];
 
-	button.titleLabel.textAlignment=UITextAlignmentCenter;
+	button.titleLabel.textAlignment=TA_CENTER;
 	[button.titleLabel setNumberOfLines:0];
 	button.titleLabel.lineBreakMode=BT_LBM;
 	[button setTitleEdgeInsets:UIEdgeInsetsMake(10.0, 10.0, 10.0, 10.0)];


### PR DESCRIPTION
Signed-off-by: Alexander Sychev asychev@poloniumarts.com
