### PR TITLE
Fix a bottom scrollview content size mis-calculate bug. Not show horizon...

### DIFF
--- a/CXAlertView/CXAlertView.m
+++ b/CXAlertView/CXAlertView.m
@@ -512,6 +512,7 @@ static CXAlertView *__cx_alert_current_view;
     if (!_bottomScrollView) {
         _bottomScrollView = [[CXAlertButtonContainerView alloc] init];
         _bottomScrollView.defaultTopLineVisible = _showButtonLine;
+        _bottomScrollView.showsHorizontalScrollIndicator = NO;
     }
 }
 
@@ -835,7 +836,12 @@ static CXAlertView *__cx_alert_current_view;
 
 	[_bottomScrollView addSubview:button];
 
-	CGFloat newContentWidth = self.bottomScrollView.contentSize.width + CGRectGetWidth(button.frame);
+    CGFloat newContentWidth = 0;
+    if ([_buttons count] <= 2) {
+        newContentWidth = self.containerWidth;
+    } else {
+        newContentWidth = self.bottomScrollView.contentSize.width + CGRectGetWidth(button.frame);
+    }
 	_bottomScrollView.contentSize = CGSizeMake( newContentWidth, _bottomScrollView.contentSize.height);
 }
 


### PR DESCRIPTION
...tal scrollview indicator by default.

 It should not add a half container size to content size when buttons count equal to 2.
Horizontal scrollview indicator helps nothing when use finger to scroll the view. (hidden it)

Before:
![before](https://cloud.githubusercontent.com/assets/1056803/4179581/5e724b82-36cc-11e4-95ce-509a0fdee3b2.gif)

After:
![after](https://cloud.githubusercontent.com/assets/1056803/4179582/6175e71c-36cc-11e4-9b5d-4c7349be669d.gif)
