### PR TITLE
Fix iOS 8 iPad landscape background window display.

### DIFF
--- a/CXAlertView/CXAlertView.m
+++ b/CXAlertView/CXAlertView.m
@@ -355,12 +355,16 @@ static CXAlertView *__cx_alert_current_view;
 {
     if (!__cx_alert_background_window) {
         CGRect frame;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
         if ([[UIScreen mainScreen] respondsToSelector:@selector(nativeBounds)]) {
             frame = [UIScreen mainScreen].nativeBounds;
         }
         else {
             frame = [UIScreen mainScreen].bounds;
         }
+#else
+        frame = [UIScreen mainScreen].bounds;
+#endif
         __cx_alert_background_window = [[CXAlertBackgroundWindow alloc] initWithFrame:frame];
 
         [__cx_alert_background_window makeKeyAndVisible];


### PR DESCRIPTION
Hi Chris,

On iOS 8 iPads in landscape orientation the background window for your alert view gets displayed off-center due to Apple changing the behavior of -[UIScreen bounds]. Using the new -nativeBounds makes the behavior the same as it is on iOS 7.
