### PR TITLE
fixed background window frame for ios < 8.0

### DIFF
--- a/CXAlertView/CXAlertView.m
+++ b/CXAlertView/CXAlertView.m
@@ -427,7 +427,7 @@ static BOOL __cx_statsu_prefersStatusBarHidden;
     CGFloat screenHeight = frame.size.height;
     
     UIInterfaceOrientation interfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
-    if (UIInterfaceOrientationIsLandscape(interfaceOrientation)) {
+    if (UIInterfaceOrientationIsLandscape(interfaceOrientation) && ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0)) {
         CGFloat tmp = screenWidth;
         screenWidth = screenHeight;
         screenHeight = tmp;


### PR DESCRIPTION
With 1.1.0 background wax fixed for ios 8.0 but broken for 7.0 and probably earlier versions (can't check). This small change fixes background window frame for ios 7.0