### PR TITLE
Added support for frameworks and Carthage package manager

### DIFF
--- a/CXAlertView-Carthage.xcodeproj/project.pbxproj
+++ b/CXAlertView-Carthage.xcodeproj/project.pbxproj
@@ -1,0 +1,136 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		7E29B15A1B3D74E300C9266D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7E29B1541B3D74E300C9266D /* CXAlertView-iOS.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 7ED8924D1B3D6A8900094A27;
+			remoteInfo = "CXAlertView-iOS";
+		};
+		7E29B15C1B3D74E300C9266D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7E29B1541B3D74E300C9266D /* CXAlertView-iOS.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 7ED8927C1B3D6C9F00094A27;
+			remoteInfo = "CXAlertView-iOS-dynamic";
+		};
+		7E29B15E1B3D74E300C9266D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7E29B1541B3D74E300C9266D /* CXAlertView-iOS.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 7ED892A41B3D6D5A00094A27;
+			remoteInfo = "CXAlertView-iOS-static";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		7E29B1541B3D74E300C9266D /* CXAlertView-iOS.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "CXAlertView-iOS.xcodeproj"; path = "CXAlertView-iOS/CXAlertView-iOS.xcodeproj"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		7E29B14D1B3D74CF00C9266D = {
+			isa = PBXGroup;
+			children = (
+				7E29B1541B3D74E300C9266D /* CXAlertView-iOS.xcodeproj */,
+			);
+			sourceTree = "<group>";
+		};
+		7E29B1551B3D74E300C9266D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7E29B15B1B3D74E300C9266D /* libCXAlertView-iOS.a */,
+				7E29B15D1B3D74E300C9266D /* CXAlertView.framework */,
+				7E29B15F1B3D74E300C9266D /* CXAlertView.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+		7E29B14E1B3D74CF00C9266D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0630;
+			};
+			buildConfigurationList = 7E29B1511B3D74CF00C9266D /* Build configuration list for PBXProject "CXAlertView-Carthage" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 7E29B14D1B3D74CF00C9266D;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 7E29B1551B3D74E300C9266D /* Products */;
+					ProjectRef = 7E29B1541B3D74E300C9266D /* CXAlertView-iOS.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		7E29B15B1B3D74E300C9266D /* libCXAlertView-iOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libCXAlertView-iOS.a";
+			remoteRef = 7E29B15A1B3D74E300C9266D /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		7E29B15D1B3D74E300C9266D /* CXAlertView.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CXAlertView.framework;
+			remoteRef = 7E29B15C1B3D74E300C9266D /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		7E29B15F1B3D74E300C9266D /* CXAlertView.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CXAlertView.framework;
+			remoteRef = 7E29B15E1B3D74E300C9266D /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin XCBuildConfiguration section */
+		7E29B1521B3D74CF00C9266D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		7E29B1531B3D74CF00C9266D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7E29B1511B3D74CF00C9266D /* Build configuration list for PBXProject "CXAlertView-Carthage" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7E29B1521B3D74CF00C9266D /* Debug */,
+				7E29B1531B3D74CF00C9266D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 7E29B14E1B3D74CF00C9266D /* Project object */;
+}

--- a/CXAlertView-iOS/CXAlertView-iOS-dynamic/CXAlertView-iOS-dynamic.h
+++ b/CXAlertView-iOS/CXAlertView-iOS-dynamic/CXAlertView-iOS-dynamic.h
@@ -1,0 +1,19 @@
+//
+//  CXAlertView-iOS-dynamic.h
+//  CXAlertView-iOS-dynamic
+//
+//  Created by Oleksandr Dodatko on 6/26/15.
+//  Copyright (c) 2015 healthjoy. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for CXAlertView-iOS-dynamic.
+FOUNDATION_EXPORT double CXAlertView_iOS_dynamicVersionNumber;
+
+//! Project version string for CXAlertView-iOS-dynamic.
+FOUNDATION_EXPORT const unsigned char CXAlertView_iOS_dynamicVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <CXAlertView_iOS_dynamic/PublicHeader.h>
+
+

--- a/CXAlertView-iOS/CXAlertView-iOS-dynamic/Info.plist
+++ b/CXAlertView-iOS/CXAlertView-iOS-dynamic/Info.plist
@@ -13,12 +13,14 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>BNDL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/CXAlertView-iOS/CXAlertView-iOS-static/CXAlertView-iOS-static.h
+++ b/CXAlertView-iOS/CXAlertView-iOS-static/CXAlertView-iOS-static.h
@@ -1,0 +1,19 @@
+//
+//  CXAlertView-iOS-static.h
+//  CXAlertView-iOS-static
+//
+//  Created by Oleksandr Dodatko on 6/26/15.
+//  Copyright (c) 2015 healthjoy. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for CXAlertView-iOS-static.
+FOUNDATION_EXPORT double CXAlertView_iOS_staticVersionNumber;
+
+//! Project version string for CXAlertView-iOS-static.
+FOUNDATION_EXPORT const unsigned char CXAlertView_iOS_staticVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <CXAlertView_iOS_static/PublicHeader.h>
+
+

--- a/CXAlertView-iOS/CXAlertView-iOS-static/Info.plist
+++ b/CXAlertView-iOS/CXAlertView-iOS-static/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.healthjoy.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/CXAlertView-iOS/CXAlertView-iOS.xcodeproj/project.pbxproj
+++ b/CXAlertView-iOS/CXAlertView-iOS.xcodeproj/project.pbxproj
@@ -13,6 +13,27 @@
 		7ED892751B3D6AAC00094A27 /* CXAlertViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED8926F1B3D6AAC00094A27 /* CXAlertViewController.m */; };
 		7ED892761B3D6AAC00094A27 /* CXBlurView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED892711B3D6AAC00094A27 /* CXBlurView.m */; };
 		7ED892811B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED892801B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ED892951B3D6CDB00094A27 /* CXAlertButtonContainerView.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED892681B3D6AAC00094A27 /* CXAlertButtonContainerView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ED892961B3D6CDB00094A27 /* CXAlertButtonItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED8926A1B3D6AAC00094A27 /* CXAlertButtonItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ED892971B3D6CDB00094A27 /* CXAlertView.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED8926C1B3D6AAC00094A27 /* CXAlertView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ED892981B3D6CDB00094A27 /* CXAlertViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED8926E1B3D6AAC00094A27 /* CXAlertViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ED892991B3D6CDB00094A27 /* CXBlurView.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED892701B3D6AAC00094A27 /* CXBlurView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ED8929A1B3D6CEA00094A27 /* CXAlertButtonContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED892691B3D6AAC00094A27 /* CXAlertButtonContainerView.m */; };
+		7ED8929B1B3D6CEA00094A27 /* CXAlertButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED8926B1B3D6AAC00094A27 /* CXAlertButtonItem.m */; };
+		7ED8929C1B3D6CEA00094A27 /* CXAlertView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED8926D1B3D6AAC00094A27 /* CXAlertView.m */; };
+		7ED8929D1B3D6CEA00094A27 /* CXAlertViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED8926F1B3D6AAC00094A27 /* CXAlertViewController.m */; };
+		7ED8929E1B3D6CEA00094A27 /* CXBlurView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED892711B3D6AAC00094A27 /* CXBlurView.m */; };
+		7ED892A91B3D6D5A00094A27 /* CXAlertView-iOS-static.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED892A81B3D6D5A00094A27 /* CXAlertView-iOS-static.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ED892BD1B3D6D6900094A27 /* CXAlertButtonContainerView.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED892681B3D6AAC00094A27 /* CXAlertButtonContainerView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ED892BE1B3D6D6900094A27 /* CXAlertButtonItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED8926A1B3D6AAC00094A27 /* CXAlertButtonItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ED892BF1B3D6D6900094A27 /* CXAlertView.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED8926C1B3D6AAC00094A27 /* CXAlertView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ED892C01B3D6D6900094A27 /* CXAlertViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED8926E1B3D6AAC00094A27 /* CXAlertViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ED892C11B3D6D6900094A27 /* CXBlurView.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED892701B3D6AAC00094A27 /* CXBlurView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ED892C21B3D6D7100094A27 /* CXAlertButtonContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED892691B3D6AAC00094A27 /* CXAlertButtonContainerView.m */; };
+		7ED892C31B3D6D7100094A27 /* CXAlertButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED8926B1B3D6AAC00094A27 /* CXAlertButtonItem.m */; };
+		7ED892C41B3D6D7100094A27 /* CXAlertView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED8926D1B3D6AAC00094A27 /* CXAlertView.m */; };
+		7ED892C51B3D6D7100094A27 /* CXAlertViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED8926F1B3D6AAC00094A27 /* CXAlertViewController.m */; };
+		7ED892C61B3D6D7100094A27 /* CXBlurView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED892711B3D6AAC00094A27 /* CXBlurView.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -39,9 +60,12 @@
 		7ED8926F1B3D6AAC00094A27 /* CXAlertViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CXAlertViewController.m; sourceTree = "<group>"; };
 		7ED892701B3D6AAC00094A27 /* CXBlurView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CXBlurView.h; sourceTree = "<group>"; };
 		7ED892711B3D6AAC00094A27 /* CXBlurView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CXBlurView.m; sourceTree = "<group>"; };
-		7ED8927C1B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "CXAlertView-iOS-dynamic.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7ED8927C1B3D6C9F00094A27 /* CXAlertView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CXAlertView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7ED8927F1B3D6C9F00094A27 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7ED892801B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CXAlertView-iOS-dynamic.h"; sourceTree = "<group>"; };
+		7ED892A41B3D6D5A00094A27 /* CXAlertView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CXAlertView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7ED892A71B3D6D5A00094A27 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7ED892A81B3D6D5A00094A27 /* CXAlertView-iOS-static.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CXAlertView-iOS-static.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +83,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7ED892A01B3D6D5A00094A27 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -67,6 +98,7 @@
 			children = (
 				7ED892671B3D6AAC00094A27 /* CXAlertView */,
 				7ED8927D1B3D6C9F00094A27 /* CXAlertView-iOS-dynamic */,
+				7ED892A51B3D6D5A00094A27 /* CXAlertView-iOS-static */,
 				7ED8924E1B3D6A8900094A27 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -75,7 +107,8 @@
 			isa = PBXGroup;
 			children = (
 				7ED8924D1B3D6A8900094A27 /* libCXAlertView-iOS.a */,
-				7ED8927C1B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.framework */,
+				7ED8927C1B3D6C9F00094A27 /* CXAlertView.framework */,
+				7ED892A41B3D6D5A00094A27 /* CXAlertView.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -115,6 +148,23 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		7ED892A51B3D6D5A00094A27 /* CXAlertView-iOS-static */ = {
+			isa = PBXGroup;
+			children = (
+				7ED892A81B3D6D5A00094A27 /* CXAlertView-iOS-static.h */,
+				7ED892A61B3D6D5A00094A27 /* Supporting Files */,
+			);
+			path = "CXAlertView-iOS-static";
+			sourceTree = "<group>";
+		};
+		7ED892A61B3D6D5A00094A27 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				7ED892A71B3D6D5A00094A27 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -123,6 +173,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				7ED892811B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.h in Headers */,
+				7ED892971B3D6CDB00094A27 /* CXAlertView.h in Headers */,
+				7ED892961B3D6CDB00094A27 /* CXAlertButtonItem.h in Headers */,
+				7ED892951B3D6CDB00094A27 /* CXAlertButtonContainerView.h in Headers */,
+				7ED892981B3D6CDB00094A27 /* CXAlertViewController.h in Headers */,
+				7ED892991B3D6CDB00094A27 /* CXBlurView.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7ED892A11B3D6D5A00094A27 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7ED892A91B3D6D5A00094A27 /* CXAlertView-iOS-static.h in Headers */,
+				7ED892BF1B3D6D6900094A27 /* CXAlertView.h in Headers */,
+				7ED892BE1B3D6D6900094A27 /* CXAlertButtonItem.h in Headers */,
+				7ED892BD1B3D6D6900094A27 /* CXAlertButtonContainerView.h in Headers */,
+				7ED892C01B3D6D6900094A27 /* CXAlertViewController.h in Headers */,
+				7ED892C11B3D6D6900094A27 /* CXBlurView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -161,7 +229,25 @@
 			);
 			name = "CXAlertView-iOS-dynamic";
 			productName = "CXAlertView-iOS-dynamic";
-			productReference = 7ED8927C1B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.framework */;
+			productReference = 7ED8927C1B3D6C9F00094A27 /* CXAlertView.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		7ED892A31B3D6D5A00094A27 /* CXAlertView-iOS-static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7ED892B71B3D6D5A00094A27 /* Build configuration list for PBXNativeTarget "CXAlertView-iOS-static" */;
+			buildPhases = (
+				7ED8929F1B3D6D5A00094A27 /* Sources */,
+				7ED892A01B3D6D5A00094A27 /* Frameworks */,
+				7ED892A11B3D6D5A00094A27 /* Headers */,
+				7ED892A21B3D6D5A00094A27 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "CXAlertView-iOS-static";
+			productName = "CXAlertView-iOS-static";
+			productReference = 7ED892A41B3D6D5A00094A27 /* CXAlertView.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -177,6 +263,9 @@
 						CreatedOnToolsVersion = 6.3.2;
 					};
 					7ED8927B1B3D6C9F00094A27 = {
+						CreatedOnToolsVersion = 6.3.2;
+					};
+					7ED892A31B3D6D5A00094A27 = {
 						CreatedOnToolsVersion = 6.3.2;
 					};
 				};
@@ -195,12 +284,20 @@
 			targets = (
 				7ED8924C1B3D6A8900094A27 /* CXAlertView-iOS */,
 				7ED8927B1B3D6C9F00094A27 /* CXAlertView-iOS-dynamic */,
+				7ED892A31B3D6D5A00094A27 /* CXAlertView-iOS-static */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		7ED8927A1B3D6C9F00094A27 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7ED892A21B3D6D5A00094A27 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -226,6 +323,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7ED8929D1B3D6CEA00094A27 /* CXAlertViewController.m in Sources */,
+				7ED8929E1B3D6CEA00094A27 /* CXBlurView.m in Sources */,
+				7ED8929B1B3D6CEA00094A27 /* CXAlertButtonItem.m in Sources */,
+				7ED8929A1B3D6CEA00094A27 /* CXAlertButtonContainerView.m in Sources */,
+				7ED8929C1B3D6CEA00094A27 /* CXAlertView.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7ED8929F1B3D6D5A00094A27 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7ED892C51B3D6D7100094A27 /* CXAlertViewController.m in Sources */,
+				7ED892C61B3D6D7100094A27 /* CXBlurView.m in Sources */,
+				7ED892C31B3D6D7100094A27 /* CXAlertButtonItem.m in Sources */,
+				7ED892C21B3D6D7100094A27 /* CXAlertButtonContainerView.m in Sources */,
+				7ED892C41B3D6D7100094A27 /* CXAlertView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -357,7 +471,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = CXAlertView;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -378,7 +492,56 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = CXAlertView;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		7ED892B81B3D6D5A00094A27 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "CXAlertView-iOS-static/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = CXAlertView;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		7ED892B91B3D6D5A00094A27 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "CXAlertView-iOS-static/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_NAME = CXAlertView;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -411,6 +574,14 @@
 			buildConfigurations = (
 				7ED892901B3D6C9F00094A27 /* Debug */,
 				7ED892911B3D6C9F00094A27 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		7ED892B71B3D6D5A00094A27 /* Build configuration list for PBXNativeTarget "CXAlertView-iOS-static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7ED892B81B3D6D5A00094A27 /* Debug */,
+				7ED892B91B3D6D5A00094A27 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/CXAlertView-iOS/CXAlertView-iOS.xcodeproj/project.pbxproj
+++ b/CXAlertView-iOS/CXAlertView-iOS.xcodeproj/project.pbxproj
@@ -7,23 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7ED892591B3D6A8900094A27 /* libCXAlertView-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7ED8924D1B3D6A8900094A27 /* libCXAlertView-iOS.a */; };
 		7ED892721B3D6AAC00094A27 /* CXAlertButtonContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED892691B3D6AAC00094A27 /* CXAlertButtonContainerView.m */; };
 		7ED892731B3D6AAC00094A27 /* CXAlertButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED8926B1B3D6AAC00094A27 /* CXAlertButtonItem.m */; };
 		7ED892741B3D6AAC00094A27 /* CXAlertView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED8926D1B3D6AAC00094A27 /* CXAlertView.m */; };
 		7ED892751B3D6AAC00094A27 /* CXAlertViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED8926F1B3D6AAC00094A27 /* CXAlertViewController.m */; };
 		7ED892761B3D6AAC00094A27 /* CXBlurView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED892711B3D6AAC00094A27 /* CXBlurView.m */; };
+		7ED892811B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED892801B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		7ED8925A1B3D6A8900094A27 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 7ED892451B3D6A8900094A27 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7ED8924C1B3D6A8900094A27;
-			remoteInfo = "CXAlertView-iOS";
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		7ED8924B1B3D6A8900094A27 /* CopyFiles */ = {
@@ -39,8 +29,6 @@
 
 /* Begin PBXFileReference section */
 		7ED8924D1B3D6A8900094A27 /* libCXAlertView-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libCXAlertView-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		7ED892581B3D6A8900094A27 /* CXAlertView-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CXAlertView-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		7ED8925E1B3D6A8900094A27 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7ED892681B3D6AAC00094A27 /* CXAlertButtonContainerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CXAlertButtonContainerView.h; sourceTree = "<group>"; };
 		7ED892691B3D6AAC00094A27 /* CXAlertButtonContainerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CXAlertButtonContainerView.m; sourceTree = "<group>"; };
 		7ED8926A1B3D6AAC00094A27 /* CXAlertButtonItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CXAlertButtonItem.h; sourceTree = "<group>"; };
@@ -51,6 +39,9 @@
 		7ED8926F1B3D6AAC00094A27 /* CXAlertViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CXAlertViewController.m; sourceTree = "<group>"; };
 		7ED892701B3D6AAC00094A27 /* CXBlurView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CXBlurView.h; sourceTree = "<group>"; };
 		7ED892711B3D6AAC00094A27 /* CXBlurView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CXBlurView.m; sourceTree = "<group>"; };
+		7ED8927C1B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "CXAlertView-iOS-dynamic.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7ED8927F1B3D6C9F00094A27 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7ED892801B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CXAlertView-iOS-dynamic.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,11 +52,10 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7ED892551B3D6A8900094A27 /* Frameworks */ = {
+		7ED892781B3D6C9F00094A27 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7ED892591B3D6A8900094A27 /* libCXAlertView-iOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -76,7 +66,7 @@
 			isa = PBXGroup;
 			children = (
 				7ED892671B3D6AAC00094A27 /* CXAlertView */,
-				7ED8925C1B3D6A8900094A27 /* CXAlertView-iOSTests */,
+				7ED8927D1B3D6C9F00094A27 /* CXAlertView-iOS-dynamic */,
 				7ED8924E1B3D6A8900094A27 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -85,25 +75,9 @@
 			isa = PBXGroup;
 			children = (
 				7ED8924D1B3D6A8900094A27 /* libCXAlertView-iOS.a */,
-				7ED892581B3D6A8900094A27 /* CXAlertView-iOSTests.xctest */,
+				7ED8927C1B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.framework */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		7ED8925C1B3D6A8900094A27 /* CXAlertView-iOSTests */ = {
-			isa = PBXGroup;
-			children = (
-				7ED8925D1B3D6A8900094A27 /* Supporting Files */,
-			);
-			path = "CXAlertView-iOSTests";
-			sourceTree = "<group>";
-		};
-		7ED8925D1B3D6A8900094A27 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				7ED8925E1B3D6A8900094A27 /* Info.plist */,
-			);
-			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
 		7ED892671B3D6AAC00094A27 /* CXAlertView */ = {
@@ -124,7 +98,35 @@
 			path = ../CXAlertView;
 			sourceTree = "<group>";
 		};
+		7ED8927D1B3D6C9F00094A27 /* CXAlertView-iOS-dynamic */ = {
+			isa = PBXGroup;
+			children = (
+				7ED892801B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.h */,
+				7ED8927E1B3D6C9F00094A27 /* Supporting Files */,
+			);
+			path = "CXAlertView-iOS-dynamic";
+			sourceTree = "<group>";
+		};
+		7ED8927E1B3D6C9F00094A27 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				7ED8927F1B3D6C9F00094A27 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		7ED892791B3D6C9F00094A27 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7ED892811B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		7ED8924C1B3D6A8900094A27 /* CXAlertView-iOS */ = {
@@ -144,23 +146,23 @@
 			productReference = 7ED8924D1B3D6A8900094A27 /* libCXAlertView-iOS.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		7ED892571B3D6A8900094A27 /* CXAlertView-iOSTests */ = {
+		7ED8927B1B3D6C9F00094A27 /* CXAlertView-iOS-dynamic */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 7ED892641B3D6A8900094A27 /* Build configuration list for PBXNativeTarget "CXAlertView-iOSTests" */;
+			buildConfigurationList = 7ED8928F1B3D6C9F00094A27 /* Build configuration list for PBXNativeTarget "CXAlertView-iOS-dynamic" */;
 			buildPhases = (
-				7ED892541B3D6A8900094A27 /* Sources */,
-				7ED892551B3D6A8900094A27 /* Frameworks */,
-				7ED892561B3D6A8900094A27 /* Resources */,
+				7ED892771B3D6C9F00094A27 /* Sources */,
+				7ED892781B3D6C9F00094A27 /* Frameworks */,
+				7ED892791B3D6C9F00094A27 /* Headers */,
+				7ED8927A1B3D6C9F00094A27 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				7ED8925B1B3D6A8900094A27 /* PBXTargetDependency */,
 			);
-			name = "CXAlertView-iOSTests";
-			productName = "CXAlertView-iOSTests";
-			productReference = 7ED892581B3D6A8900094A27 /* CXAlertView-iOSTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
+			name = "CXAlertView-iOS-dynamic";
+			productName = "CXAlertView-iOS-dynamic";
+			productReference = 7ED8927C1B3D6C9F00094A27 /* CXAlertView-iOS-dynamic.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
@@ -174,7 +176,7 @@
 					7ED8924C1B3D6A8900094A27 = {
 						CreatedOnToolsVersion = 6.3.2;
 					};
-					7ED892571B3D6A8900094A27 = {
+					7ED8927B1B3D6C9F00094A27 = {
 						CreatedOnToolsVersion = 6.3.2;
 					};
 				};
@@ -192,13 +194,13 @@
 			projectRoot = "";
 			targets = (
 				7ED8924C1B3D6A8900094A27 /* CXAlertView-iOS */,
-				7ED892571B3D6A8900094A27 /* CXAlertView-iOSTests */,
+				7ED8927B1B3D6C9F00094A27 /* CXAlertView-iOS-dynamic */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		7ED892561B3D6A8900094A27 /* Resources */ = {
+		7ED8927A1B3D6C9F00094A27 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -220,7 +222,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7ED892541B3D6A8900094A27 /* Sources */ = {
+		7ED892771B3D6C9F00094A27 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -228,14 +230,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		7ED8925B1B3D6A8900094A27 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 7ED8924C1B3D6A8900094A27 /* CXAlertView-iOS */;
-			targetProxy = 7ED8925A1B3D6A8900094A27 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		7ED8925F1B3D6A8900094A27 /* Debug */ = {
@@ -345,35 +339,50 @@
 			};
 			name = Release;
 		};
-		7ED892651B3D6A8900094A27 /* Debug */ = {
+		7ED892901B3D6C9F00094A27 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				INFOPLIST_FILE = "CXAlertView-iOSTests/Info.plist";
+				INFOPLIST_FILE = "CXAlertView-iOS-dynamic/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
-		7ED892661B3D6A8900094A27 /* Release */ = {
+		7ED892911B3D6C9F00094A27 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = "CXAlertView-iOSTests/Info.plist";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "CXAlertView-iOS-dynamic/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
@@ -397,11 +406,11 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
-		7ED892641B3D6A8900094A27 /* Build configuration list for PBXNativeTarget "CXAlertView-iOSTests" */ = {
+		7ED8928F1B3D6C9F00094A27 /* Build configuration list for PBXNativeTarget "CXAlertView-iOS-dynamic" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7ED892651B3D6A8900094A27 /* Debug */,
-				7ED892661B3D6A8900094A27 /* Release */,
+				7ED892901B3D6C9F00094A27 /* Debug */,
+				7ED892911B3D6C9F00094A27 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/CXAlertView-iOS/CXAlertView-iOS.xcodeproj/project.pbxproj
+++ b/CXAlertView-iOS/CXAlertView-iOS.xcodeproj/project.pbxproj
@@ -1,0 +1,411 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		7ED892591B3D6A8900094A27 /* libCXAlertView-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7ED8924D1B3D6A8900094A27 /* libCXAlertView-iOS.a */; };
+		7ED892721B3D6AAC00094A27 /* CXAlertButtonContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED892691B3D6AAC00094A27 /* CXAlertButtonContainerView.m */; };
+		7ED892731B3D6AAC00094A27 /* CXAlertButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED8926B1B3D6AAC00094A27 /* CXAlertButtonItem.m */; };
+		7ED892741B3D6AAC00094A27 /* CXAlertView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED8926D1B3D6AAC00094A27 /* CXAlertView.m */; };
+		7ED892751B3D6AAC00094A27 /* CXAlertViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED8926F1B3D6AAC00094A27 /* CXAlertViewController.m */; };
+		7ED892761B3D6AAC00094A27 /* CXBlurView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED892711B3D6AAC00094A27 /* CXBlurView.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		7ED8925A1B3D6A8900094A27 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7ED892451B3D6A8900094A27 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7ED8924C1B3D6A8900094A27;
+			remoteInfo = "CXAlertView-iOS";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		7ED8924B1B3D6A8900094A27 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		7ED8924D1B3D6A8900094A27 /* libCXAlertView-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libCXAlertView-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7ED892581B3D6A8900094A27 /* CXAlertView-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CXAlertView-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7ED8925E1B3D6A8900094A27 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7ED892681B3D6AAC00094A27 /* CXAlertButtonContainerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CXAlertButtonContainerView.h; sourceTree = "<group>"; };
+		7ED892691B3D6AAC00094A27 /* CXAlertButtonContainerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CXAlertButtonContainerView.m; sourceTree = "<group>"; };
+		7ED8926A1B3D6AAC00094A27 /* CXAlertButtonItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CXAlertButtonItem.h; sourceTree = "<group>"; };
+		7ED8926B1B3D6AAC00094A27 /* CXAlertButtonItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CXAlertButtonItem.m; sourceTree = "<group>"; };
+		7ED8926C1B3D6AAC00094A27 /* CXAlertView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CXAlertView.h; sourceTree = "<group>"; };
+		7ED8926D1B3D6AAC00094A27 /* CXAlertView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CXAlertView.m; sourceTree = "<group>"; };
+		7ED8926E1B3D6AAC00094A27 /* CXAlertViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CXAlertViewController.h; sourceTree = "<group>"; };
+		7ED8926F1B3D6AAC00094A27 /* CXAlertViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CXAlertViewController.m; sourceTree = "<group>"; };
+		7ED892701B3D6AAC00094A27 /* CXBlurView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CXBlurView.h; sourceTree = "<group>"; };
+		7ED892711B3D6AAC00094A27 /* CXBlurView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CXBlurView.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		7ED8924A1B3D6A8900094A27 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7ED892551B3D6A8900094A27 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7ED892591B3D6A8900094A27 /* libCXAlertView-iOS.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		7ED892441B3D6A8900094A27 = {
+			isa = PBXGroup;
+			children = (
+				7ED892671B3D6AAC00094A27 /* CXAlertView */,
+				7ED8925C1B3D6A8900094A27 /* CXAlertView-iOSTests */,
+				7ED8924E1B3D6A8900094A27 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		7ED8924E1B3D6A8900094A27 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7ED8924D1B3D6A8900094A27 /* libCXAlertView-iOS.a */,
+				7ED892581B3D6A8900094A27 /* CXAlertView-iOSTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		7ED8925C1B3D6A8900094A27 /* CXAlertView-iOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				7ED8925D1B3D6A8900094A27 /* Supporting Files */,
+			);
+			path = "CXAlertView-iOSTests";
+			sourceTree = "<group>";
+		};
+		7ED8925D1B3D6A8900094A27 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				7ED8925E1B3D6A8900094A27 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		7ED892671B3D6AAC00094A27 /* CXAlertView */ = {
+			isa = PBXGroup;
+			children = (
+				7ED892681B3D6AAC00094A27 /* CXAlertButtonContainerView.h */,
+				7ED892691B3D6AAC00094A27 /* CXAlertButtonContainerView.m */,
+				7ED8926A1B3D6AAC00094A27 /* CXAlertButtonItem.h */,
+				7ED8926B1B3D6AAC00094A27 /* CXAlertButtonItem.m */,
+				7ED8926C1B3D6AAC00094A27 /* CXAlertView.h */,
+				7ED8926D1B3D6AAC00094A27 /* CXAlertView.m */,
+				7ED8926E1B3D6AAC00094A27 /* CXAlertViewController.h */,
+				7ED8926F1B3D6AAC00094A27 /* CXAlertViewController.m */,
+				7ED892701B3D6AAC00094A27 /* CXBlurView.h */,
+				7ED892711B3D6AAC00094A27 /* CXBlurView.m */,
+			);
+			name = CXAlertView;
+			path = ../CXAlertView;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		7ED8924C1B3D6A8900094A27 /* CXAlertView-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7ED892611B3D6A8900094A27 /* Build configuration list for PBXNativeTarget "CXAlertView-iOS" */;
+			buildPhases = (
+				7ED892491B3D6A8900094A27 /* Sources */,
+				7ED8924A1B3D6A8900094A27 /* Frameworks */,
+				7ED8924B1B3D6A8900094A27 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "CXAlertView-iOS";
+			productName = "CXAlertView-iOS";
+			productReference = 7ED8924D1B3D6A8900094A27 /* libCXAlertView-iOS.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		7ED892571B3D6A8900094A27 /* CXAlertView-iOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7ED892641B3D6A8900094A27 /* Build configuration list for PBXNativeTarget "CXAlertView-iOSTests" */;
+			buildPhases = (
+				7ED892541B3D6A8900094A27 /* Sources */,
+				7ED892551B3D6A8900094A27 /* Frameworks */,
+				7ED892561B3D6A8900094A27 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7ED8925B1B3D6A8900094A27 /* PBXTargetDependency */,
+			);
+			name = "CXAlertView-iOSTests";
+			productName = "CXAlertView-iOSTests";
+			productReference = 7ED892581B3D6A8900094A27 /* CXAlertView-iOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7ED892451B3D6A8900094A27 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0630;
+				ORGANIZATIONNAME = healthjoy;
+				TargetAttributes = {
+					7ED8924C1B3D6A8900094A27 = {
+						CreatedOnToolsVersion = 6.3.2;
+					};
+					7ED892571B3D6A8900094A27 = {
+						CreatedOnToolsVersion = 6.3.2;
+					};
+				};
+			};
+			buildConfigurationList = 7ED892481B3D6A8900094A27 /* Build configuration list for PBXProject "CXAlertView-iOS" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 7ED892441B3D6A8900094A27;
+			productRefGroup = 7ED8924E1B3D6A8900094A27 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7ED8924C1B3D6A8900094A27 /* CXAlertView-iOS */,
+				7ED892571B3D6A8900094A27 /* CXAlertView-iOSTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7ED892561B3D6A8900094A27 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7ED892491B3D6A8900094A27 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7ED892751B3D6AAC00094A27 /* CXAlertViewController.m in Sources */,
+				7ED892761B3D6AAC00094A27 /* CXBlurView.m in Sources */,
+				7ED892731B3D6AAC00094A27 /* CXAlertButtonItem.m in Sources */,
+				7ED892721B3D6AAC00094A27 /* CXAlertButtonContainerView.m in Sources */,
+				7ED892741B3D6AAC00094A27 /* CXAlertView.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7ED892541B3D6A8900094A27 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		7ED8925B1B3D6A8900094A27 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7ED8924C1B3D6A8900094A27 /* CXAlertView-iOS */;
+			targetProxy = 7ED8925A1B3D6A8900094A27 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		7ED8925F1B3D6A8900094A27 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					..,
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = NO;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		7ED892601B3D6A8900094A27 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					..,
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				ONLY_ACTIVE_ARCH = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		7ED892621B3D6A8900094A27 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		7ED892631B3D6A8900094A27 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		7ED892651B3D6A8900094A27 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "CXAlertView-iOSTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		7ED892661B3D6A8900094A27 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "CXAlertView-iOSTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7ED892481B3D6A8900094A27 /* Build configuration list for PBXProject "CXAlertView-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7ED8925F1B3D6A8900094A27 /* Debug */,
+				7ED892601B3D6A8900094A27 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7ED892611B3D6A8900094A27 /* Build configuration list for PBXNativeTarget "CXAlertView-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7ED892621B3D6A8900094A27 /* Debug */,
+				7ED892631B3D6A8900094A27 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		7ED892641B3D6A8900094A27 /* Build configuration list for PBXNativeTarget "CXAlertView-iOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7ED892651B3D6A8900094A27 /* Debug */,
+				7ED892661B3D6A8900094A27 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 7ED892451B3D6A8900094A27 /* Project object */;
+}

--- a/CXAlertView-iOS/CXAlertView-iOS.xcodeproj/xcshareddata/xcschemes/CXAlertView-iOS-dynamic.xcscheme
+++ b/CXAlertView-iOS/CXAlertView-iOS.xcodeproj/xcshareddata/xcschemes/CXAlertView-iOS-dynamic.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7ED8927B1B3D6C9F00094A27"
+               BuildableName = "CXAlertView.framework"
+               BlueprintName = "CXAlertView-iOS-dynamic"
+               ReferencedContainer = "container:CXAlertView-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7ED8927B1B3D6C9F00094A27"
+            BuildableName = "CXAlertView.framework"
+            BlueprintName = "CXAlertView-iOS-dynamic"
+            ReferencedContainer = "container:CXAlertView-iOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7ED8927B1B3D6C9F00094A27"
+            BuildableName = "CXAlertView.framework"
+            BlueprintName = "CXAlertView-iOS-dynamic"
+            ReferencedContainer = "container:CXAlertView-iOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7ED8927B1B3D6C9F00094A27"
+            BuildableName = "CXAlertView.framework"
+            BlueprintName = "CXAlertView-iOS-dynamic"
+            ReferencedContainer = "container:CXAlertView-iOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CXAlertView-iOS/CXAlertView-iOSTests/Info.plist
+++ b/CXAlertView-iOS/CXAlertView-iOSTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.healthjoy.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/CXAlertView/CXAlertButtonContainerView.h
+++ b/CXAlertView/CXAlertButtonContainerView.h
@@ -7,7 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "CXAlertView.h"
+#import <CXAlertView/CXAlertView.h>
+
 
 @interface CXAlertButtonContainerView : UIScrollView
 

--- a/CXAlertView/CXAlertButtonItem.h
+++ b/CXAlertView/CXAlertButtonItem.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-//#import "CXAlertView.h"
+
 typedef NS_ENUM(NSInteger, CXAlertViewButtonType) {
     CXAlertViewButtonTypeDefault = 0,
     CXAlertViewButtonTypeCustom = 1,

--- a/CXAlertView/CXAlertView.h
+++ b/CXAlertView/CXAlertView.h
@@ -7,9 +7,11 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "CXAlertButtonItem.h"
+#import <CXAlertView/CXAlertButtonItem.h>
 
 @class CXAlertView;
+
+
 typedef void(^CXAlertViewHandler)(CXAlertView *alertView);
 @interface CXAlertView : UIView
 

--- a/CXAlertView/CXAlertViewController.h
+++ b/CXAlertView/CXAlertViewController.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "CXAlertView.h"
+#import <CXAlertView/CXAlertView.h>
 
 @interface CXAlertViewController : UIViewController
 


### PR DESCRIPTION
```
github "healthjoy-ios-opensource/CXAlertView" "4ec9d7c71514b3b70422a756e5a6d9b300fdfdb4"
```
Here is a ```Cartfile``` to test the patch.
A separate tag is required to make it available to the end users.