### PR TITLE
Set _contentScrollView.autoresizesSubviews to NO

### DIFF
--- a/CXAlertView/CXAlertView.m
+++ b/CXAlertView/CXAlertView.m
@@ -582,6 +582,7 @@ static BOOL __cx_statsu_prefersStatusBarHidden;
 
     if (!_contentScrollView) {
         _contentScrollView = [[UIScrollView alloc] init];
+        _contentScrollView.autoresizesSubviews = NO;
     }
 
     if (!_bottomScrollView) {


### PR DESCRIPTION
Use customized contentView and autolayout, contentView will missplace. Set _contentScrollView.autoresizesSubviews to NO will fix this problem.